### PR TITLE
updated mocha-jsdom version issue

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "expect": "^1.20.2",
     "jsdom": "^9.2.1",
     "mocha": "^2.5.3",
-    "mocha-jsdom": "^1.1.0",
+    "mocha-jsdom": "~1.1.0",
     "mocha-multi": "^0.9.0"
   }
 }


### PR DESCRIPTION
Breaking update to mocha-jsdom that causes error not allowing tests to run. Updated mocha-jsdom version to allow tests to successfully run.